### PR TITLE
Make Tagbot run on demand to fix warnings

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,11 +1,15 @@
 name: TagBot
 on:
-  schedule:
-    - cron: 0 * * * *
+  issue_comment:  # THIS BIT IS NEW
+    types:
+      - created
+  workflow_dispatch:
 jobs:
   TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
As documented [here](https://discourse.julialang.org/t/ann-required-updates-to-tagbot-yml/49249) this will avoid the warnings we're getting from the tagbot actions:
![image](https://github.com/fugro-oss/LAS.jl/assets/73566276/7bcb768e-d44f-420d-8e9a-babe09c1ac9e)
