### PR TITLE
use read!(io, array) instead of PointIterator

### DIFF
--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -11,7 +11,7 @@ LASDatasets.make_consistent_header
 
 ## Third Party Packages
 
-This package relies heavily upon [PackedReadWrite.jl](https://github.com/EvertSchippers/PackedReadWrite.jl) to speed up the reading and writing of `LasPoint`s and some of our *VLRs*. 
+This package relies heavily upon [PackedReadWrite.jl](https://github.com/EvertSchippers/PackedReadWrite.jl) to speed up the reading and writing of `LasPoint`s and some of our *VLRs*.
 
 We also use [BufferedStreams.jl](https://github.com/JuliaIO/BufferedStreams.jl) to drastically reduce I/O overhead.
 
@@ -29,21 +29,13 @@ LASDatasets.FullRecord
 
 This was done largely to increase performance of reading point records, since having one single type for point records would require more conditional checks to see if certain extra fields need to be read from a file which ends up congesting the read process. Instead, we use *Julia*'s multiple dispatch and define `Base.read` and `Base.write` methods for each record type and avoid these checks and also decrease the type inference time when reading these into a vector.
 
-## Reading Points Iterator
-
-When reading, we also wrap our IO stream in an iterator, `LASDatasets.ReadPointsIterator`, to reduce the overhead of reading point records sequentially. It turns out that calling `map(r -> r, iter)` where `iter` is a `LASDatasets.ReadPointsIterator` is much faster than calling `map(_ -> read(io, TRecord), 1:num_points)`
-
-```@docs; canonical = false
-LASDatasets.ReadPointsIterator
-```
-
 ## Writing Optimisations
 Typically, *Julia* is slower at performing multiple consecutive smaller writes to an IO channel than one much larger write. For this reason, when writing point records to a *LAS* file, we first construct a vector of bytes from the records and then write that whole vector to the file. This is possible since for each point record we know:
 * How many bytes the point format is,
 * How many user fields in this record and their data size in bytes and
 * How many undocumented bytes there are.
 
-This is done using `LASDatasets.get_record_bytes`, which takes a collection of *LAS* records and writes each *LAS* field, user field and extra bytes collection into its correct location in the final byte vector. 
+This is done using `LASDatasets.get_record_bytes`, which takes a collection of *LAS* records and writes each *LAS* field, user field and extra bytes collection into its correct location in the final byte vector.
 
 In order to do this, we need to frequently access each field in a (potentially huge) list of records, which in normal circumstances is slow. We instead first pass our records into a `StructVector` using [StructArrays.jl](https://github.com/JuliaArrays/StructArrays.jl) which vastly increases the speed at which we can access these fields and broadcast over them.
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -62,7 +62,7 @@ function open_laz(func::Function, file::String, rw::String = "r")
 
         try
             return func(io)
-        finally        
+        finally
             close(io)
             rm(las_file, force=true)
         end
@@ -77,9 +77,9 @@ function open_laz(func::Function, file::String, rw::String = "r")
             result = func(io)
             success = true
             return result
-        finally        
+        finally
             close(io)
-            
+
             if (success)
                 mkpath(dirname(file))
                 run(`$(laszip()) -i $(las_file) -o $(file)`)
@@ -87,7 +87,7 @@ function open_laz(func::Function, file::String, rw::String = "r")
 
             rm(las_file, force=true)
         end
-        
+
     else
         error("Read \"r\" OR write \"w\".")
     end
@@ -96,7 +96,7 @@ end
 is_laz(file_name::AbstractString) = endswith(file_name, ".laz")
 
 function get_open_func(file_name::String)
-    ext = String(split(file_name, ".", keepempty = false)[end])
+    ext = lowercase(String(split(file_name, ".", keepempty = false)[end]))
     @assert (ext == "las") || (ext == "laz") "Invalid file extension! Require .las or .laz files"
     open_func = (ext == "las") ? open_las : open_laz
     return open_func


### PR DESCRIPTION
I was trying to improve performance for reading Pointclouds and found a low hanging fruit here:

#### With the Point iterator:
4.083 s (32316360 allocations: 1.53 GiB)
#### with just read!(io, array)
3.724 s (10773706 allocations: 1.05 GiB)

Sorry for the noise in the PR, I really need to disable auto formatting of VSCode.
If you wish I can remove the other changes.