### PR TITLE
Custom VLR Registration Bug

### DIFF
--- a/src/constants.jl
+++ b/src/constants.jl
@@ -36,6 +36,5 @@ const DEFAULT_LAS_COLUMNS = (:position, :intensity, :classification, :returnnumb
 const ALL_LAS_COLUMNS = nothing
 
 POINT_SCALE = 0.0001
-global const _VLR_TYPE_MAP = Dict()
 
 const SUPPORTED_EXTRA_BYTES_TYPES = [UInt8, Int8, UInt16, Int16, UInt32, Int32, UInt64, Int64, Float32, Float64]

--- a/src/read.jl
+++ b/src/read.jl
@@ -257,7 +257,7 @@ end
 Convert the position units of some `pointcloud` data into metres based upon the coordinate units in the LAS file's `vlrs`.
 Can override the unit conversion by manually specifying a unit to convert on the *XY*-plane, `convert_x_y_units`, and/or a unit to convert on the z-axis `convert_z_units` (missing if not overriding)
 """
-function convert_units!(pointcloud::AbstractVector{<:NamedTuple}, vlrs::Vector{LasVariableLengthRecord}, convert_x_y_units::Union{Missing, String}, convert_z_units::Union{Missing, String})
+function convert_units!(pointcloud::AbstractVector{<:NamedTuple}, vlrs::Vector{LasVariableLengthRecord}, convert_x_y_units::Union{Missing, String}, convert_z_units::Union{Missing, String}; verbose::Bool = false)
     if :position ∈ columnnames(pointcloud)
         these_are_wkts = is_ogc_wkt_record.(vlrs)
         # we are not requesting unit conversion and there is no OGC WKT VLR
@@ -268,7 +268,7 @@ function convert_units!(pointcloud::AbstractVector{<:NamedTuple}, vlrs::Vector{L
             ogc_wkt = get_data(vlrs[findfirst(these_are_wkts)])
             conversion = conversion_from_vlrs(ogc_wkt, convert_x_y_units = convert_x_y_units, convert_z_units = convert_z_units)
             if !ismissing(conversion) && any(conversion .!= 1.0)
-                @info "Positions converted to meters using conversion $(conversion)"
+                verbose && @info "Positions converted to meters using conversion $(conversion)"
                 pointcloud = pointcloud.position .= map(p -> p .* conversion, pointcloud.position)
                 return conversion
             else

--- a/src/records.jl
+++ b/src/records.jl
@@ -183,7 +183,7 @@ function Base.read(io::IO, ::Type{UndocPointRecord{TPoint, N}}) where {TPoint <:
 end
 
 get_point_format(::Type{UndocPointRecord{TPoint, N}}) where {TPoint, N} = TPoint
-get_num_user_field_bytes(::Type{UndocPointRecord}) = 0
+get_num_user_field_bytes(::Type{TRecord}) where {TRecord <: UndocPointRecord} = 0
 get_num_undocumented_bytes(::Type{UndocPointRecord{TPoint, N}}) where {TPoint, N} = N
 get_undocumented_bytes(record::UndocPointRecord) = record.undoc_bytes
 

--- a/src/vlrs.jl
+++ b/src/vlrs.jl
@@ -7,7 +7,7 @@ To properly define I/O methods for VLR's of custom structs, you must register wh
 will use using 
 
 ```julia
-@register_vlr_type(TData, user_id, record_ids)
+@register_vlr_type TData user_id record_ids
 ```
 
 And overload the methods `read_vlr_data` and `write_vlr_data` for your type `TData`
@@ -127,30 +127,50 @@ official_record_ids(::Type{TData}) where TData = error("Official record IDs not 
 """
     $(TYPEDSIGNATURES)
 
+Get the data type associated with a particular `user_id` and `record_id`. 
+This is used to automatically parse VLR data types on reading
+"""
+data_type_from_ids(::Val{User}, ::Val{Record}) where {User, Record} = Vector{UInt8}
+
+# convenience function so you don't have to worry about wrapping Vals
+data_type_from_ids(user_id::String, record_id::Integer) = data_type_from_ids(Val(Symbol(user_id)), Val(record_id))
+
+"""
+    $(TYPEDSIGNATURES)
+
 Register a new VLR data type `type` by associating it with an official `user_id` and set of `record_ids` 
 """
 macro register_vlr_type(type, user_id, record_ids)
     return quote
+        this_record_ids = $(esc(record_ids))
+        
         # restrict types for inputs
         if !($(esc(type)) isa DataType) && !($(esc(type)) isa UnionAll)
             throw(AssertionError("Type must be a DataType, not $(typeof($(esc(type))))"))
         end
+        
         if !($(esc(user_id)) isa AbstractString)
             throw(AssertionError("User ID must be a String, not $(typeof($(esc(user_id))))"))
         elseif Base.sizeof($(esc(user_id))) > 16
             throw(AssertionError("User ID must be at most 16 bytes in length! Got $(Base.sizeof($(esc(user_id)))) bytes"))
         end
-        if !(($(esc(record_ids))) isa AbstractVector{<:Integer})
+        
+        if !(this_record_ids isa AbstractVector{<:Integer})
             # if we've only entered a single number, put it in an array and carry on
-            if $(esc(record_ids)) isa Integer
-                record_ids = [$(esc(record_ids))]
+            if this_record_ids isa Integer
+                this_record_ids = [this_record_ids]
             else
-                throw(AssertionError("Record IDs must be a vector of Integers, not $(typeof($(esc(record_ids))))"))
+                throw(AssertionError("Record IDs must be a vector of Integers, not $(typeof(this_record_ids))"))
             end
         end 
-        LASDatasets.official_record_ids(::Type{$(esc(type))}) = $(esc(record_ids))
+
+        LASDatasets.official_record_ids(::Type{$(esc(type))}) = this_record_ids
         LASDatasets.official_user_id(::Type{$(esc(type))}) = $(esc(user_id))
-        global LASDatasets._VLR_TYPE_MAP[($(esc(user_id)), $(esc(record_ids)))] = $(esc(type))
+
+        # for each combination of (user_id, record_id), make a method to get the expected data type for that combination
+        for id ∈ this_record_ids
+            LASDatasets.data_type_from_ids(::Val{Symbol($(esc(user_id)))}, ::Val{id}) = $(esc(type))
+        end
     end
 end
 
@@ -174,23 +194,6 @@ By default this will call `Base.write`, but for more specific write methods this
 """
 function write_vlr_data(io::IO, data::TData) where TData
     return write(io, data)
-end
-
-"""
-    $(TYPEDSIGNATURES)
-
-Get the data type associated with a particular `user_id` and `record_id`. 
-This is used to automatically parse VLR data types on reading
-"""
-function data_type_from_ids(user_id::String, record_id::Integer)
-    matched_type = Vector{UInt8}
-    for k ∈ keys(LASDatasets._VLR_TYPE_MAP)
-        if (user_id == k[1]) && (record_id ∈ k[2])
-            matched_type = LASDatasets._VLR_TYPE_MAP[k]
-            break
-        end
-    end
-    return matched_type
 end
 
 function Base.read(io::IO, ::Type{LasVariableLengthRecord}, extended::Bool=false)

--- a/src/vlrs.jl
+++ b/src/vlrs.jl
@@ -133,7 +133,7 @@ This is used to automatically parse VLR data types on reading
 data_type_from_ids(::Val{User}, ::Val{Record}) where {User, Record} = Vector{UInt8}
 
 # convenience function so you don't have to worry about wrapping Vals
-data_type_from_ids(user_id::String, record_id::Integer) = data_type_from_ids(Val(Symbol(user_id)), Val(record_id))
+data_type_from_ids(user_id::String, record_id::Integer) = data_type_from_ids(Val(Symbol(user_id)), Val(Int(record_id)))
 
 """
     $(TYPEDSIGNATURES)
@@ -169,7 +169,7 @@ macro register_vlr_type(type, user_id, record_ids)
 
         # for each combination of (user_id, record_id), make a method to get the expected data type for that combination
         for id ∈ this_record_ids
-            LASDatasets.data_type_from_ids(::Val{Symbol($(esc(user_id)))}, ::Val{id}) = $(esc(type))
+            LASDatasets.data_type_from_ids(::Val{Symbol($(esc(user_id)))}, ::Val{Int(id)}) = $(esc(type))
         end
     end
 end

--- a/src/vlrs.jl
+++ b/src/vlrs.jl
@@ -143,9 +143,9 @@ function data_type_from_ids(user_id::String, record_id::Integer)
 end
 
 function get_all_vlr_types()
-    # eval to make sure we get the methods in the global scope
-    ms = @eval methods(LASDatasets.official_record_ids)
-    types = DataType[]
+    # eval to make sure we get the methods in the global scope - use both the user and record IDs methods to check for types
+    ms = @eval vcat(methods(LASDatasets.official_user_id), methods(LASDatasets.official_record_ids))
+    types = Set{DataType}()
     for m ∈ ms
         sig = m.sig
         if !(sig isa UnionAll)
@@ -153,7 +153,7 @@ function get_all_vlr_types()
             push!(types, eval(sig.parameters[2].parameters[1]))
         end
     end
-    return types
+    return collect(types)
 end
 
 """

--- a/test/vlrs.jl
+++ b/test/vlrs.jl
@@ -120,8 +120,11 @@
         @test_throws AssertionError @register_vlr_type [1, 2, 3] "User ID" [1, 2]
 
         @register_vlr_type Vector{Int} "User ID" [1, 2]
-        @test ("User ID", [1, 2]) ∈ keys(LASDatasets._VLR_TYPE_MAP) && (LASDatasets._VLR_TYPE_MAP["User ID", [1, 2]] == Vector{Int})
-        
+
+        for i ∈ 1:2
+            @test LASDatasets.data_type_from_ids("User ID", i) == Vector{Int}
+        end
+
         @register_vlr_type String "Custom" collect(10:15)
         LASDatasets.read_vlr_data(io::IO, ::Type{String}, nb::Integer) = LASDatasets.readstring(io, nb)
         


### PR DESCRIPTION
> Issue : [#39](https://github.com/fugro-oss/LASDatasets.jl/issues/39)

## Description

This is to correct the issue reported in [#39](https://github.com/fugro-oss/LASDatasets.jl/issues/39) where registration of custom VLR data types wasn't working when those types and registrations were done in another module. 

This seems to be due to how Julia scopes code, where (AFAIK) if you have Pkg A exporting a value (like a dict) and Pkg B uses Pkg A and modifies that value, any functions within Pkg A that rely on that value won't be updated with the new value since Pkg A and Pkg B have different scopes.

The solution I'm proposing here isn't ideal, but it avoids having to hard code a mapping of user/record ID combinations and find a way to modify them from upstream sources. Basically, we now use multi-dispatch on each combination of (user_id, record_id). This creates alot of method instances which may not be great when trying to serialise, so potentially will need to look into this further.

## Types of Changes

- Bug fix (non-breaking change which fixes an issue)
- Configuration change

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG
