### PR TITLE
Replace ArchGDAL dep with Proj.jl instead

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,9 @@
 name = "LASDatasets"
 uuid = "cc498e2a-d443-4943-8f26-2a8a0f3c7cdb"
 authors = ["BenCurran98 <b.curran@fugro.com>"]
-version = "0.2.3"
+version = "0.3.0"
 
 [deps]
-ArchGDAL = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"
 BufferedStreams = "e1450e63-4bb3-523b-b2a4-4ffa8c0fd77d"
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -15,12 +14,12 @@ LAStools_jll = "2502db7c-e51e-5cc5-b107-5f8e6dbfe9b6"
 PackedReadWrite = "5d6e2f64-5c87-46b6-9ff4-cf810e78676d"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+Proj = "c94c279d-25a6-4763-9509-64d165bea63e"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 TypedTables = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
 
 [compat]
-ArchGDAL = "0.10"
 BufferedStreams = "1"
 ColorTypes = "0.11"
 DocStringExtensions = "0.9"

--- a/src/LASDatasets.jl
+++ b/src/LASDatasets.jl
@@ -1,6 +1,5 @@
 module LASDatasets
 
-using ArchGDAL: importWKT, toPROJ4
 using BufferedStreams
 using ColorTypes
 using Dates
@@ -11,6 +10,7 @@ using LAStools_jll
 using PackedReadWrite
 import Pkg.Types: read_project
 using Printf
+using Proj
 using StaticArrays
 using StructArrays
 using TypedTables


### PR DESCRIPTION
# Remove Large Dependency ArchGDAL.jl

> Issue : #37 

## Description
This is to replace the dependence on [ArchGDAL.jl](https://github.com/yeesian/ArchGDAL.jl) (which is a very large package with alot of artifacts to load) with the smaller [Proj.jl](https://github.com/JuliaGeo/Proj.jl). 
Since we only need this for unit conversion, I've modified the way we extract PROJ strings from OGC WKT VLR's to use Proj.jl's functionality, keeping everything else the same.

## Types of Changes

- Configuration change
- Refactor/improvements

## Review
_List of tasks the reviewer must do to review the PR_
- [x] Tests
- [x] Documentation
- [x] CHANGELOG
