### PR TITLE
Default to raw bytes for vlr types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LASDatasets"
 uuid = "cc498e2a-d443-4943-8f26-2a8a0f3c7cdb"
 authors = ["BenCurran98 <b.curran@fugro.com>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 BufferedStreams = "e1450e63-4bb3-523b-b2a4-4ffa8c0fd77d"
@@ -21,7 +21,7 @@ TypedTables = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
 
 [compat]
 BufferedStreams = "1"
-ColorTypes = "0.11"
+ColorTypes = "0.11, 0.12"
 DocStringExtensions = "0.9"
 FileIO = "1"
 FixedPointNumbers = "0.8"

--- a/src/vlrs.jl
+++ b/src/vlrs.jl
@@ -129,6 +129,7 @@ official_record_ids(::Type{TData}) where TData = error("Official record IDs not 
 
 Get the data type associated with a particular `user_id` and `record_id`. 
 This is used to automatically parse VLR data types on reading
+**NOTE**: If the user and record ID combination hasn't been registered, will default to `Vector{UInt8}` and the *VLR* data will be returned as raw bytes.
 """
 function data_type_from_ids(user_id::String, record_id::Integer)
     registered_vlr_types = get_all_vlr_types()
@@ -139,7 +140,9 @@ function data_type_from_ids(user_id::String, record_id::Integer)
         end
     end
 
-    error("Can't find VLR data type to parse for user ID $(user_id) and record ID $(record_id)")
+    # if we can't find a registered type, just read it out as a Byte Vector
+    @warn "Can't find VLR data type to parse for user ID $(user_id) and record ID $(record_id) - reading as raw bytes"
+    return Vector{UInt8}
 end
 
 function get_all_vlr_types()


### PR DESCRIPTION
# Read raw bytes if user + record ID combo not registered

## Description
This was a bug introduced in the recent internal VLR changes where an error is thrown if the provided combination of VLR user and record IDs haven't been registered. This is incorrect, as the default behaviour for an unregistered pair should be just to read the raw bytes. I've updated this and added some explicit tests for handling it

## Types of Changes
- Bug fix (non-breaking change which fixes an issue)

## Review
_List of tasks the reviewer must do to review the PR_
- [x] Tests
- [x] Documentation
