### PR TITLE
Fix EVLR offset bug

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,6 +27,7 @@ FileIO = "1"
 FixedPointNumbers = "0.8"
 PackedReadWrite = "0.1"
 Proj = "1"
+Random = "1.11.0"
 StaticArrays = "1"
 StructArrays = "0.6"
 TypedTables = "1"
@@ -34,6 +35,7 @@ julia = "1.8"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Random"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LASDatasets"
 uuid = "cc498e2a-d443-4943-8f26-2a8a0f3c7cdb"
 authors = ["BenCurran98 <b.curran@fugro.com>"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 BufferedStreams = "e1450e63-4bb3-523b-b2a4-4ffa8c0fd77d"

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -179,10 +179,11 @@ get_unit_conversion(las::LASDataset) = las.unit_conversion
 
 Update the offset (in Bytes) to the first EVLR in a `LASDataset` `las`
 """
-function update_evlr_offset!(las::LASDataset)
-    header = get_header(las)
+function update_evlr_offset!(header::LasHeader)
     header.evlr_start = point_data_offset(header) + (number_of_points(header) * point_record_length(header))
 end
+
+update_evlr_offset!(las::LASDataset) = update_evlr_offset!(get_header(las))
 
 function Base.show(io::IO, las::LASDataset)
     println(io, "LAS Dataset")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,9 +2,13 @@ using LASDatasets
 
 using ColorTypes
 using FixedPointNumbers
+using Random
 using StaticArrays
 using Test
 using TypedTables
+
+# fix random seed to avoid random errors
+Random.seed!(0)
 
 include("util.jl")
 include("spatial_info.jl")


### PR DESCRIPTION
# EVLR Offset Bug Fix

## Description
This is to fix a bug where when we add VLRs or point record data, we weren't updating the offset to the first EVLR in the header properly, which essentially corrupts the files. I've added an explicit step to update this every time we add VLR's or column data plus some additional tests to avoid this in future

## Types of Changes

- Bug fix (non-breaking change which fixes an issue)

## Review
_List of tasks the reviewer must do to review the PR_
- [x] Tests
- [x] Documentation
- [x] CHANGELOG
