### PR TITLE
add a constructor that just needs the pointcloud

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LASDatasets"
 uuid = "cc498e2a-d443-4943-8f26-2a8a0f3c7cdb"
 authors = ["BenCurran98 <b.curran@fugro.com>"]
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 BufferedStreams = "e1450e63-4bb3-523b-b2a4-4ffa8c0fd77d"

--- a/README.md
+++ b/README.md
@@ -49,5 +49,5 @@ This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md
 
 This package started as a fork off of [LasIO.jl](https://github.com/visr/LasIO.jl), with modifications being made to add *LAS* v1.4 support and some *API*/functionality changes. 
 
-* Thanks to [@visr](https://github.com/visr) as the authour of the *LasIO.jl* package
+* Thanks to [@visr](https://github.com/visr) as the author of the *LasIO.jl* package
 * Thanks to all developers in *LasIO.jl* and [*LazIO.jl*](https://github.com/evetion/LazIO.jl), including [@evetion](https://github.com/evetion)

--- a/src/LASDatasets.jl
+++ b/src/LASDatasets.jl
@@ -38,7 +38,7 @@ export scan_direction, user_data
 
 # header interface
 export LasHeader, is_standard_gps, is_wkt, file_source_id, global_encoding, las_version, system_id, software_id, creation_day_of_year, creation_year
-export header_size, point_data_offset, point_record_length, record_format, point_format,  number_of_points, number_of_vlrs, number_of_evlrs, evlr_start, spatial_info, num_return_channels
+export header_size, point_data_offset, point_record_length, record_format, point_format,  number_of_points, number_of_vlrs, number_of_evlrs, evlr_start, spatial_info, scale, num_return_channels
 export set_las_version!, set_spatial_info!, set_point_data_offset!, set_point_format!, set_point_record_length!, set_point_record_count!, set_num_vlr!, set_num_evlr!, set_gps_week_time_bit!
 export set_gps_standard_time_bit!, is_internal_waveform, is_external_waveform, unset_wkt_bit!
 export set_waveform_external_bit!, set_waveform_internal_bit!, set_synthetic_return_numbers_bit!, unset_synthetic_return_numbers_bit!

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -125,6 +125,26 @@ mutable struct LASDataset
     end
 end
 
+"""
+    $(TYPEDSIGNATURES)
+
+Create a LASDataset from a pointcloud and optionally vlrs/evlrs/user_defined_bytes, 
+NO header required.
+"""
+function LASDataset(pointcloud::Table,
+                    vlrs::Vector{<:LasVariableLengthRecord} = LasVariableLengthRecord[],
+                    evlrs::Vector{<:LasVariableLengthRecord} = LasVariableLengthRecord[],
+                    user_defined_bytes::Vector{UInt8} = UInt8[])
+
+    point_format = get_point_format(pointcloud)
+    header = LasHeader(; 
+        las_version = lasversion_for_point(point_format), 
+        data_format_id = UInt8(get_point_format_id(point_format)),
+        data_record_length = UInt16(byte_size(point_format))
+    )
+    make_consistent_header!(header, pointcloud, vlrs, evlrs, user_defined_bytes)
+    return LASDataset(header, pointcloud, vlrs, evlrs, user_defined_bytes)
+end
 
 """
     $(TYPEDSIGNATURES)

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -131,18 +131,24 @@ end
 Create a LASDataset from a pointcloud and optionally vlrs/evlrs/user_defined_bytes, 
 NO header required.
 """
-function LASDataset(pointcloud::Table,
+function LASDataset(pointcloud::Table;
                     vlrs::Vector{<:LasVariableLengthRecord} = LasVariableLengthRecord[],
                     evlrs::Vector{<:LasVariableLengthRecord} = LasVariableLengthRecord[],
-                    user_defined_bytes::Vector{UInt8} = UInt8[])
+                    user_defined_bytes::Vector{UInt8} = UInt8[],
+                    scale::Real = POINT_SCALE)
 
     point_format = get_point_format(pointcloud)
+    spatial_info = get_spatial_info(pointcloud; scale = scale)
+
     header = LasHeader(; 
         las_version = lasversion_for_point(point_format), 
         data_format_id = UInt8(get_point_format_id(point_format)),
-        data_record_length = UInt16(byte_size(point_format))
+        data_record_length = UInt16(byte_size(point_format)),
+        spatial_info = spatial_info,
     )
+
     make_consistent_header!(header, pointcloud, vlrs, evlrs, user_defined_bytes)
+
     return LASDataset(header, pointcloud, vlrs, evlrs, user_defined_bytes)
 end
 

--- a/src/header.jl
+++ b/src/header.jl
@@ -476,11 +476,11 @@ spatial_info(h::LasHeader) = h.spatial_info
 """
     $(TYPEDSIGNATURES)
 
-Get the scale for point positions in a LAS file from a header `h`. Checks consistent scale for ALL axis.
+Get the scale for point positions in a LAS file from a header `h`. Checks consistent scale for ALL axes.
 """
 function scale(h::LasHeader) 
 
-    @assert (h.spatial_info.scale.x == h.spatial_info.scale.y) && (h.spatial_info.scale.y == h.spatial_info.scale.z) "We expect all axis to be scale similarly"
+    @assert (h.spatial_info.scale.x == h.spatial_info.scale.y) && (h.spatial_info.scale.y == h.spatial_info.scale.z) "We expect all axes to be scaled similarly"
     
     return h.spatial_info.scale.x
 end

--- a/src/header.jl
+++ b/src/header.jl
@@ -476,6 +476,18 @@ spatial_info(h::LasHeader) = h.spatial_info
 """
     $(TYPEDSIGNATURES)
 
+Get the scale for point positions in a LAS file from a header `h`. Checks consistent scale for ALL axis.
+"""
+function scale(h::LasHeader) 
+
+    @assert (h.spatial_info.scale.x == h.spatial_info.scale.y) && (h.spatial_info.scale.y == h.spatial_info.scale.z) "We expect all axis to be scale similarly"
+    
+    return h.spatial_info.scale.x
+end
+
+"""
+    $(TYPEDSIGNATURES)
+
 Get the number of return channels in a LAS file from a header `h`
 """
 num_return_channels(h::LasHeader) = las_version(h) ≥ v"1.4" ? 15 : 5
@@ -792,6 +804,7 @@ function make_consistent_header!(header::LasHeader,
     point_data_offset = header_size + vlr_size + length(user_defined_bytes)
     
     set_point_data_offset!(header, point_data_offset)
+    set_spatial_info!(header, get_spatial_info(pointcloud; scale = scale(header)))
     
     set_point_record_count!(header, length(pointcloud))
     returns = (:returnnumber ∈ columnnames(pointcloud)) ? pointcloud.returnnumber : ones(Int, length(pointcloud))

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -44,6 +44,12 @@
     # check equality if we create two of the same dataset
     other_las = LASDataset(deepcopy(header), deepcopy(pc), LasVariableLengthRecord[], LasVariableLengthRecord[], UInt8[])
     @test other_las == las
+
+    # test constructor with pc Only
+    h = LasHeader(; las_version = v"1.1", data_format_id = UInt8(1), data_record_length = UInt16(28))
+    LASDatasets.make_consistent_header!(h, pc, LasVariableLengthRecord[], LasVariableLengthRecord[], UInt8[])
+    las = LASDataset(h, pc, LasVariableLengthRecord[], LasVariableLengthRecord[], UInt8[])
+    @test las == LASDataset(deepcopy(pc))
     
     # now try incorporating some user fields
     spicy_pc = Table(pc, thing = rand(num_points), other_thing = rand(Int16, num_points))


### PR DESCRIPTION
# Add a LASDataset constructor from a pointcloud (no preconstructed header required)

## Description
Minor change to add a constructor from ONLY a pointcloud

## Types of Changes
- New feature (non-breaking change which adds functionality)

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

