### PR TITLE
Flexibly Modify Point Contents

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LASDatasets"
 uuid = "cc498e2a-d443-4943-8f26-2a8a0f3c7cdb"
 authors = ["BenCurran98 <b.curran@fugro.com>"]
-version = "0.3.3"
+version = "0.4.0"
 
 [deps]
 BufferedStreams = "e1450e63-4bb3-523b-b2a4-4ffa8c0fd77d"

--- a/docs/src/header.md
+++ b/docs/src/header.md
@@ -38,6 +38,7 @@ You can also modify certain fields in the header, but one should note that for s
 
 ```@docs; canonical = false
 set_las_version!
+set_point_format!
 set_spatial_info!
 set_point_data_offset!
 set_point_record_length!

--- a/docs/src/interface.md
+++ b/docs/src/interface.md
@@ -77,12 +77,13 @@ save_las("my_las.las", pc)
 Note that when you supply just the point cloud outside of a `LASDataset`, *LASDatasets.jl* will automatically construct the appropriate header for you so you don't need to worry about the specifics of appropriate point formats etc. 
 
 ## Modifying LAS Contents
-You can modify point fields in your `LASDataset` by adding new columns or merging in values from an existing vector. Additionally, you can add new points to your dataset, however one should note that the user is responsible for correctly setting the appropriate fields such as synthetic flags themselves.
+You can modify point fields in your `LASDataset` by adding new columns or merging in values from an existing vector. Additionally, you can add new points to your dataset or remove them, however one should note when adding points that the user is responsible for correctly setting the appropriate fields such as synthetic flags themselves.
 
 ```@docs; canonical = false
 add_column!
 merge_column!
 add_points!
+remove_points!
 ```
 
 For example, if you want to add a set of synthetic points to your dataset, you can run:
@@ -92,6 +93,11 @@ las = load_las("my_las.las")
 add_column!(las, :synthetic, falses(number_of_points(las)))
 synthetic_points = Table(position = rand(SVector{3, Float64}, 5), classification = rand(UInt8, 5), synthetic = trues(5))
 add_points!(las, synthetic_points)
+```
+
+You can remove points from your data using the `remove_points!` function and specifying the indices of the points you wish to delete (these will be indexing into the list of points in order). E.g.
+```julia
+remove_points!(las, 11:15)
 ```
 
 You can also add or remove *(E)VLRs* using the following functions, and set an existing *(E)VLR* as *superseded* if it's an old copy of a record.

--- a/docs/src/interface.md
+++ b/docs/src/interface.md
@@ -70,18 +70,28 @@ Alternatively, if you just have the point cloud data as a Table:
 using StaticArrays
 using TypedTables
 
-pc = Table(position = rand(SVector{3, Float64}, 10), classification = rand(UIn8, 10))
+pc = Table(position = rand(SVector{3, Float64}, 10), classification = rand(UInt8, 10))
 save_las("my_las.las", pc)
 ```
 
 Note that when you supply just the point cloud outside of a `LASDataset`, *LASDatasets.jl* will automatically construct the appropriate header for you so you don't need to worry about the specifics of appropriate point formats etc. 
 
 ## Modifying LAS Contents
-You can modify point fields in your `LASDataset` by adding new columns or merging in values from an existing vector.
+You can modify point fields in your `LASDataset` by adding new columns or merging in values from an existing vector. Additionally, you can add new points to your dataset, however one should note that the user is responsible for correctly setting the appropriate fields such as synthetic flags themselves.
 
 ```@docs; canonical = false
 add_column!
 merge_column!
+add_points!
+```
+
+For example, if you want to add a set of synthetic points to your dataset, you can run:
+```julia
+las = load_las("my_las.las")
+# note - we need to set a synthetic column here for the existing points before we append points with this field
+add_column!(las, :synthetic, falses(number_of_points(las)))
+synthetic_points = Table(position = rand(SVector{3, Float64}, 5), classification = rand(UInt8, 5), synthetic = trues(5))
+add_points!(las, synthetic_points)
 ```
 
 You can also add or remove *(E)VLRs* using the following functions, and set an existing *(E)VLR* as *superseded* if it's an old copy of a record.

--- a/docs/src/interface.md
+++ b/docs/src/interface.md
@@ -77,7 +77,7 @@ save_las("my_las.las", pc)
 Note that when you supply just the point cloud outside of a `LASDataset`, *LASDatasets.jl* will automatically construct the appropriate header for you so you don't need to worry about the specifics of appropriate point formats etc. 
 
 ## Modifying LAS Contents
-You can modify point fields in your `LASDataset` by adding new columns or merging in values from an existing vector. Additionally, you can add new points to your dataset or remove them, however one should note when adding points that the user is responsible for correctly setting the appropriate fields such as synthetic flags themselves.
+You can modify point fields in your `LASDataset` by adding new columns or merging in values from an existing vector. Additionally, you can add and remove points from a dataset. When adding points, the user is responsible for correctly setting the appropriate fields (e.g. synthetic flags).
 
 ```@docs; canonical = false
 add_column!
@@ -98,6 +98,19 @@ add_points!(las, synthetic_points)
 You can remove points from your data using the `remove_points!` function and specifying the indices of the points you wish to delete (these will be indexing into the list of points in order). E.g.
 ```julia
 remove_points!(las, 11:15)
+```
+
+Note that you can also modify the contents of your points by acting directly on the tabular pointcloud data. **Note:** this should **not** be used to add/remove points or point fields, since this will cause a conflict between the data in your points and the file header. Intended use is for operations that preserve the number of points and the existing fields. 
+For example:
+
+```julia
+pc = get_pointcloud(las)
+
+# shuffle the order of the points based on point positions
+pc = pc[sortperm(pc.position)]
+
+# set all classifications to 0
+pc.classification .= 0
 ```
 
 You can also add or remove *(E)VLRs* using the following functions, and set an existing *(E)VLR* as *superseded* if it's an old copy of a record.

--- a/docs/src/vlrs.md
+++ b/docs/src/vlrs.md
@@ -62,7 +62,7 @@ You can then read the *LAS* data and extract the classification lookup:
 las = load_las("pc.las")
 # look for the classification lookup VLR by checking for its user and record IDs
 lookup_vlr = extract_vlr_type(get_vlrs(las), "LASF_Spec", 0)
-lookup = get_data(lookup_vlr[1])
+lookup = get_data(lookup_vlr)
 ```
 
 ### Text Area Descriptions
@@ -150,7 +150,7 @@ So in our example, we can tell the system that records containing data of type `
 @register_vlr_type MyType "My Custom Records" collect(1:100)
 ```
 
-And now we can save our `MyType` *VLRs* into a *LAS* file in the same way as we did above for the register *VLR* types. Note that you can use the function `extract_vlr_type` on your collection of *VLRs* to pull out any *VLRs* with a specific user ID and record ID.
+And now we can save our `MyType` *VLRs* into a *LAS* file in the same way as we did above for the register *VLR* types. Note that you can use the function `extract_vlr_type` on your collection of *VLRs* to pull out the *VLR* with a specific user ID and record ID. 
 
 ```@docs; canonical = false
 extract_vlr_type

--- a/src/LASDatasets.jl
+++ b/src/LASDatasets.jl
@@ -55,7 +55,7 @@ export get_classes, get_description, set_description!
 export @register_vlr_type, read_vlr_data, extract_vlr_type
 
 export LASDataset, get_header, get_pointcloud, get_vlrs, get_evlrs, get_user_defined_bytes, get_unit_conversion
-export add_column!, add_points!, merge_column!, add_vlr!, remove_vlr!, set_superseded!
+export add_column!, add_points!, remove_points!, merge_column!, add_vlr!, remove_vlr!, set_superseded!
 
 # I/O methods
 export load_las, load_pointcloud, save_las, load_header, load_vlrs

--- a/src/LASDatasets.jl
+++ b/src/LASDatasets.jl
@@ -39,7 +39,7 @@ export scan_direction, user_data
 # header interface
 export LasHeader, is_standard_gps, is_wkt, file_source_id, global_encoding, las_version, system_id, software_id, creation_day_of_year, creation_year
 export header_size, point_data_offset, point_record_length, record_format, point_format,  number_of_points, number_of_vlrs, number_of_evlrs, evlr_start, spatial_info, scale, num_return_channels
-export set_las_version!, set_spatial_info!, set_point_data_offset!, set_point_format!, set_point_record_length!, set_point_record_count!, set_num_vlr!, set_num_evlr!, set_gps_week_time_bit!
+export set_las_version!, set_point_format!, set_spatial_info!, set_point_data_offset!, set_point_format!, set_point_record_length!, set_point_record_count!, set_num_vlr!, set_num_evlr!, set_gps_week_time_bit!
 export set_gps_standard_time_bit!, is_internal_waveform, is_external_waveform, unset_wkt_bit!
 export set_waveform_external_bit!, set_waveform_internal_bit!, set_synthetic_return_numbers_bit!, unset_synthetic_return_numbers_bit!
 export set_wkt_bit!, get_number_of_points_by_return, set_number_of_points_by_return!, waveform_record_start

--- a/src/LASDatasets.jl
+++ b/src/LASDatasets.jl
@@ -55,7 +55,7 @@ export get_classes, get_description, set_description!
 export @register_vlr_type, read_vlr_data, extract_vlr_type
 
 export LASDataset, get_header, get_pointcloud, get_vlrs, get_evlrs, get_user_defined_bytes, get_unit_conversion
-export add_column!, merge_column!, add_vlr!, remove_vlr!, set_superseded!
+export add_column!, add_points!, merge_column!, add_vlr!, remove_vlr!, set_superseded!
 
 # I/O methods
 export load_las, load_pointcloud, save_las, load_header, load_vlrs

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -444,7 +444,9 @@ function add_points!(las::LASDataset, points::AbstractVector{<:NamedTuple})
     pc = get_pointcloud(las)
     # make new points a FlexTable so we can add any missing columns with 0 values to ensure consistency
     missing_cols = filter(c -> c ∉ columnnames(points), columnnames(pc))
-    @warn "Adding default entries for missing columns $(missing_cols)"
+    if !isempty(missing_cols)
+        @warn "Adding default entries for missing columns $(missing_cols)"
+    end
     # need to make sure columns are in the same order as in pc to avoid errors from TypedTables
     new_points = Table(NamedTuple{ (columnnames(pc)...,) }( (map(col -> hasproperty(points, col) ? getproperty(points, col) : zeros(eltype(getproperty(pc, col)), length(points)), columnnames(pc))...,) ))
     append!(pc, new_points)

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -455,6 +455,23 @@ function add_points!(las::LASDataset, points::AbstractVector{<:NamedTuple})
     return nothing
 end
 
+"""
+    $(TYPEDSIGNATURES)
+
+Remove a set of points stored at indices `idxs` from a `las` dataset. Updates header information to ensure consistency
+"""
+function remove_points!(las::LASDataset, idxs::Union{AbstractUnitRange, AbstractVector{<:Integer}})
+    pc = get_pointcloud(las)
+    @error "REMOVE"
+    @show length(pc)
+    @show length(pc.id)
+    deleteat!(pc, idxs)
+    @show length(pc)
+    @show length(pc.id)
+    _consolidate_point_header_info!(get_header(las), pc)
+    return nothing
+end
+
 # plumb through header util functions to act on a LASDataset for convenience
 for header_func ∈ (
     :las_version,

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -25,7 +25,7 @@ struct LASDataset
     unit_conversion::SVector{3, Float64}
 
     function LASDataset(header::LasHeader,
-                        pointcloud::Table,
+                        pointcloud::AbstractVector{<:NamedTuple},
                         vlrs::Vector{<:LasVariableLengthRecord},
                         evlrs::Vector{<:LasVariableLengthRecord},
                         user_defined_bytes::Vector{UInt8},
@@ -122,7 +122,7 @@ end
 Create a LASDataset from a pointcloud and optionally vlrs/evlrs/user_defined_bytes, 
 NO header required.
 """
-function LASDataset(pointcloud::Table;
+function LASDataset(pointcloud::AbstractVector{<:NamedTuple};
                     vlrs::Vector{<:LasVariableLengthRecord} = LasVariableLengthRecord[],
                     evlrs::Vector{<:LasVariableLengthRecord} = LasVariableLengthRecord[],
                     user_defined_bytes::Vector{UInt8} = UInt8[],

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -435,6 +435,20 @@ function set_point_format!(las::LASDataset, ::Type{TPoint}) where {TPoint <: Las
     set_point_format!(get_header(las), TPoint)
 end
 
+"""
+    $(TYPEDSIGNATURES)
+
+Add a collection of `points` to a `LASDataset`, `las`. Updates header information to ensure dataset consistency
+"""
+function add_points!(las::LASDataset, points::AbstractVector{<:NamedTuple})
+    pc = get_pointcloud(las)
+    @assert all(columnnames(points) .∈ Ref(columnnames(pc))) "Point fields being appended $(columnnames(points)) must match those present in the dataset, $(columnnames(pc))"
+    append!(pc, points)
+    # make sure we update the header info too!
+    _consolidate_point_header_info!(get_header(las), pc)
+    return nothing
+end
+
 # plumb through header util functions to act on a LASDataset for convenience
 for header_func ∈ (
     :las_version,
@@ -452,7 +466,7 @@ for header_func ∈ (
     :number_of_vlrs,
     :number_of_evlrs,
     :evlr_start,
-    :spatrial_info,
+    :spatial_info,
     :scale,
     :num_return_channels,
     :is_standard_gps,

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -434,3 +434,39 @@ end
 function set_point_format!(las::LASDataset, ::Type{TPoint}) where {TPoint <: LasPoint}
     set_point_format!(get_header(las), TPoint)
 end
+
+# plumb through header util functions to act on a LASDataset for convenience
+for header_func ∈ (
+    :las_version,
+    :file_source_id,
+    :global_encoding, 
+    :system_id,
+    :software_id,
+    :creation_day_of_year,
+    :creation_year,
+    :header_size,
+    :point_data_offset, 
+    :point_record_length,
+    :point_format,
+    :number_of_points,
+    :number_of_vlrs,
+    :number_of_evlrs,
+    :evlr_start,
+    :spatrial_info,
+    :scale,
+    :num_return_channels,
+    :is_standard_gps,
+    :is_wkt,
+    :set_gps_standard_time_bit!,
+    :is_internal_waveform,
+    :set_waveform_internal_bit!,
+    :set_waveform_external_bit!,
+    :unset_waveform_bits!,
+    :set_synthetic_return_numbers_bit!,
+    :unset_synthetic_return_numbers_bit!,
+    :set_wkt_bit!,
+    :get_number_of_points_by_return,
+    :waveform_record_start
+    )
+    @eval $header_func(las::LASDataset) = $header_func(get_header(las))
+end

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -126,10 +126,10 @@ function LASDataset(pointcloud::Table;
                     vlrs::Vector{<:LasVariableLengthRecord} = LasVariableLengthRecord[],
                     evlrs::Vector{<:LasVariableLengthRecord} = LasVariableLengthRecord[],
                     user_defined_bytes::Vector{UInt8} = UInt8[],
-                    scale::Real = POINT_SCALE)
+                    scale::Union{Real, SVector, AxisInfo} = POINT_SCALE)
 
     point_format = get_point_format(pointcloud)
-    spatial_info = get_spatial_info(pointcloud; scale = scale)
+    spatial_info = get_spatial_info(pointcloud, scale)
 
     header = LasHeader(; 
         las_version = lasversion_for_point(point_format), 

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -365,6 +365,9 @@ function add_column!(las::LASDataset, column::Symbol, values::AbstractVector{T})
         @warn "Changing point format to $(new_format) to allow the inclusion of LAS column $(column)"
         
         set_point_format!(las, new_format)
+
+        # special case - if we're adding synthetic points, need to set the synthetic flag in the header
+        set_synthetic_return_numbers_bit!(las)
     end
 
     # now actually write the values to the column

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -462,12 +462,7 @@ Remove a set of points stored at indices `idxs` from a `las` dataset. Updates he
 """
 function remove_points!(las::LASDataset, idxs::Union{AbstractUnitRange, AbstractVector{<:Integer}})
     pc = get_pointcloud(las)
-    @error "REMOVE"
-    @show length(pc)
-    @show length(pc.id)
     deleteat!(pc, idxs)
-    @show length(pc)
-    @show length(pc.id)
     _consolidate_point_header_info!(get_header(las), pc)
     return nothing
 end

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -371,7 +371,6 @@ function add_column!(las::LASDataset, column::Symbol, values::AbstractVector{T})
     # now actually write the values to the column
     Base.setproperty!(pointcloud, column, values)
     
-    
     return nothing
 end
 

--- a/src/header.jl
+++ b/src/header.jl
@@ -872,5 +872,10 @@ function _consolidate_point_header_info!(header::LasHeader, pointcloud::Abstract
     returns = (:returnnumber ∈ columnnames(pointcloud)) ? pointcloud.returnnumber : ones(Int, length(pointcloud))
     points_per_return = ntuple(r -> count(returns .== r), num_return_channels(header))
     set_number_of_points_by_return!(header, points_per_return)
+    if :synthetic ∈ columnnames(pointcloud)
+        set_synthetic_return_numbers_bit!(header)
+    else
+        unset_synthetic_return_numbers_bit!(header)
+    end
     return nothing
 end

--- a/src/header.jl
+++ b/src/header.jl
@@ -766,6 +766,7 @@ function set_number_of_points_by_return!(header::LasHeader, points_per_return::N
     else
         header.legacy_point_return_count = (0, 0, 0, 0, 0)
     end
+    return nothing
 end
 
 """

--- a/src/header.jl
+++ b/src/header.jl
@@ -534,6 +534,7 @@ function set_point_format!(h::LasHeader, ::Type{TPoint}) where {TPoint <: LasPoi
     h.data_record_length += (byte_size(TPoint) - byte_size(LasPoint{Int(old_format_id)}))
     set_point_record_count!(h, number_of_points(h))
     set_number_of_points_by_return!(h, get_number_of_points_by_return(h))
+    return nothing
 end
 
 """

--- a/src/header.jl
+++ b/src/header.jl
@@ -836,12 +836,8 @@ function make_consistent_header!(header::LasHeader,
     point_data_offset = header_size + vlr_size + length(user_defined_bytes)
     
     set_point_data_offset!(header, point_data_offset)
-    set_spatial_info!(header, get_spatial_info(pointcloud; scale = scale(header)))
     
-    set_point_record_count!(header, length(pointcloud))
-    returns = (:returnnumber ∈ columnnames(pointcloud)) ? pointcloud.returnnumber : ones(Int, length(pointcloud))
-    points_per_return = ntuple(r -> count(returns .== r), num_return_channels(header))
-    set_number_of_points_by_return!(header, points_per_return)
+    _consolidate_point_header_info!(header, pointcloud)
 
     if !isempty(vlrs)
         set_num_vlr!(header, length(vlrs))
@@ -865,4 +861,16 @@ function make_consistent_header!(header::LasHeader,
         # don't want waveform bits set for point formats that don't have waveform data
         unset_waveform_bits!(header)
     end
+
+    return nothing
+end
+
+function _consolidate_point_header_info!(header::LasHeader, pointcloud::AbstractVector{<:NamedTuple})
+    set_spatial_info!(header, get_spatial_info(pointcloud; scale = scale(header)))
+    
+    set_point_record_count!(header, length(pointcloud))
+    returns = (:returnnumber ∈ columnnames(pointcloud)) ? pointcloud.returnnumber : ones(Int, length(pointcloud))
+    points_per_return = ntuple(r -> count(returns .== r), num_return_channels(header))
+    set_number_of_points_by_return!(header, points_per_return)
+    return nothing
 end

--- a/src/header.jl
+++ b/src/header.jl
@@ -820,10 +820,10 @@ function make_consistent_header(pointcloud::AbstractVector{<:NamedTuple},
                                 vlrs::Vector{<:LasVariableLengthRecord}, 
                                 evlrs::Vector{<:LasVariableLengthRecord},
                                 user_defined_bytes::Vector{UInt8},
-                                scale::Union{Real, SVector{3, <:Real}}) where {TPoint <: LasPoint}
+                                scale::Union{Real, SVector{3, <:Real}, AxisInfo}) where {TPoint <: LasPoint}
     version = lasversion_for_point(point_format)
 
-    spatial_info = get_spatial_info(pointcloud; scale = scale)
+    spatial_info = get_spatial_info(pointcloud, scale)
 
     header = LasHeader(; 
         las_version = version, 

--- a/src/parse_points.jl
+++ b/src/parse_points.jl
@@ -16,9 +16,9 @@ byte_size(vector::Type{SVector{N,T}}) where {N,T} = sizeof(T) * N
 
 Get the minimum point format that is compatible with the contents of a point cloud in a `table`
 """
-function get_point_format(table::AbstractVector{<:NamedTuple})
-    
-    columns = columnnames(table)
+get_point_format(table::AbstractVector{<:NamedTuple}) = get_point_format(columnnames(table))
+
+function get_point_format(columns::Union{AbstractVector{Symbol}, NTuple{N, Symbol}}) where N
 
     # these are the known formats - the ones without wave packets
     columns_per_format = map(n -> has_columns(get_point_format(LasPoint{n})), collect(0:9))

--- a/src/parse_points.jl
+++ b/src/parse_points.jl
@@ -6,8 +6,8 @@ $(METHODLIST)
 function laspoint end
 laspoint(::Type{TPoint}, p::TPoint, xyz::SpatialInfo) where TPoint = p
 
-byte_size(point::TPoint) where {N, TPoint <: LasPoint{N}} = byte_size(TPoint)
-byte_size(::Type{TPoint}) where {N, TPoint <: LasPoint{N}} = sum(sizeof.(eltype.(fieldtypes(TPoint))))
+
+byte_size(::Type{TPoint}) where {TPoint <: LasPoint} = sum(sizeof.(eltype.(fieldtypes(get_point_format(TPoint)))))
 
 byte_size(vector::Type{SVector{N,T}}) where {N,T} = sizeof(T) * N
 

--- a/src/points.jl
+++ b/src/points.jl
@@ -227,6 +227,7 @@ Get the concrete point format struct from an abstract `LasPoint` type
 
 $(METHODLIST)
 """
+get_point_format(::Type{TPoint}) where {TPoint <: LasPoint} = TPoint
 get_point_format(::Type{LasPoint{0}}) = LasPoint0
 get_point_format(::Type{LasPoint{1}}) = LasPoint1
 get_point_format(::Type{LasPoint{2}}) = LasPoint2

--- a/src/read.jl
+++ b/src/read.jl
@@ -107,8 +107,7 @@ function read_las_data(io::TIO, required_columns::TTuple=DEFAULT_LAS_COLUMNS;
     user_defined_bytes = read(io, header.data_offset - pos)
 
     extra_bytes_vlr = extract_vlr_type(vlrs, LAS_SPEC_USER_ID, ID_EXTRABYTES)
-    @assert length(extra_bytes_vlr) ≤ 1 "Found multiple extra bytes columns!"
-    extra_bytes = isempty(extra_bytes_vlr) ? ExtraBytes[] : get_extra_bytes(get_data(extra_bytes_vlr[1]))
+    extra_bytes = isnothing(extra_bytes_vlr) ? ExtraBytes[] : get_extra_bytes(get_data(extra_bytes_vlr))
 
     this_format = record_format(header, extra_bytes)
     xyz = spatial_info(header)

--- a/src/spatial_info.jl
+++ b/src/spatial_info.jl
@@ -125,7 +125,7 @@ function get_spatial_info(points::AbstractVector{SVector{3, T}}, scale::AxisInfo
     return SpatialInfo(scale, offset, AxisInfo(Range(x_max, x_min), Range(y_max, y_min), Range(z_max, z_min)))
 end
 
-get_spatial_info(pc::Union{AbstractVector{<:NamedTuple}, FlexTable}, scale::Union{Real, SVector, AxisInfo}) = get_spatial_info(pc.position, scale)
+get_spatial_info(pc::Union{AbstractVector{<:NamedTuple}, FlexTable}, scale::Union{Real, SVector, AxisInfo} = POINT_SCALE) = get_spatial_info(pc.position, scale)
 
 function determine_offset(min_value, max_value, scale; threshold=10^7)
     s = round(Int64, ((min_value + max_value) / 2) / scale / threshold)

--- a/src/spatial_info.jl
+++ b/src/spatial_info.jl
@@ -68,7 +68,7 @@ Base.write(io::IO, info::SpatialInfo) = write_struct(io, info)
 
 const DEFAULT_SPATIAL_INFO = SpatialInfo(AxisInfo(POINT_SCALE, POINT_SCALE, POINT_SCALE), AxisInfo(0.0, 0.0, 0.0), AxisInfo(Range(Inf, -Inf), Range(Inf, -Inf), Range(Inf, -Inf)))
 
-function bounding_box(points::Vector{SVector{3, T}}) where {T <: Real}
+function bounding_box(points::AbstractVector{SVector{3, T}}) where {T <: Real}
     x_min = typemax(T)
     x_max = typemin(T)
     y_min = typemax(T)
@@ -103,7 +103,7 @@ function bounding_box(points::Vector{SVector{3, T}}) where {T <: Real}
     return (; xmin = x_min, ymin = y_min, zmin = z_min, xmax = x_max, ymax = y_max, zmax = z_max)
 end
 
-function get_spatial_info(points::Vector{SVector{3, T}}; scale::T = T(POINT_SCALE)) where {T <: Real}
+function get_spatial_info(points::AbstractVector{SVector{3, T}}; scale::T = T(POINT_SCALE)) where {T <: Real}
     bb = bounding_box(points)
 
     x_offset = determine_offset(bb.xmin, bb.xmax, scale)

--- a/src/spatial_info.jl
+++ b/src/spatial_info.jl
@@ -128,9 +128,6 @@ end
 get_spatial_info(pc::Union{AbstractVector{<:NamedTuple}, FlexTable}, scale::Union{Real, SVector, AxisInfo}) = get_spatial_info(pc.position, scale)
 
 function determine_offset(min_value, max_value, scale; threshold=10^7)
-    @show scale
-    @show min_value, max_value
-    @show threshold
     s = round(Int64, ((min_value + max_value) / 2) / scale / threshold)
     s *= threshold * scale
     # Try to convert back and forth and check overflow

--- a/src/spatial_info.jl
+++ b/src/spatial_info.jl
@@ -103,7 +103,7 @@ function bounding_box(points::AbstractVector{SVector{3, T}}) where {T <: Real}
     return (; xmin = x_min, ymin = y_min, zmin = z_min, xmax = x_max, ymax = y_max, zmax = z_max)
 end
 
-get_spatial_info(points::AbstractVector{SVector{3, T}}; scale::T = T(POINT_SCALE)) where {T <: Real} = get_spatial_info(points, AxisInfo{T}(scale, scale, scale))
+get_spatial_info(points::AbstractVector{SVector{3, T}}, scale::T = T(POINT_SCALE)) where {T <: Real} = get_spatial_info(points, AxisInfo{T}(scale, scale, scale))
 get_spatial_info(points::AbstractVector{SVector{3, T}}, scale::SVector{3, T}) where {T <: Real} = get_spatial_info(points, AxisInfo{T}(scale.x, scale.y, scale.z))
 
 function get_spatial_info(points::AbstractVector{SVector{3, T}}, scale::AxisInfo{T}) where {T <: Real}
@@ -125,10 +125,12 @@ function get_spatial_info(points::AbstractVector{SVector{3, T}}, scale::AxisInfo
     return SpatialInfo(scale, offset, AxisInfo(Range(x_max, x_min), Range(y_max, y_min), Range(z_max, z_min)))
 end
 
-get_spatial_info(pc::Union{AbstractVector{<:NamedTuple}, FlexTable}; kwargs...) = get_spatial_info(pc.position; kwargs...)
-get_spatial_info(pc::Union{AbstractVector{<:NamedTuple}, FlexTable}, scale::Union{SVector, AxisInfo}) = get_spatial_info(pc.position, scale)
+get_spatial_info(pc::Union{AbstractVector{<:NamedTuple}, FlexTable}, scale::Union{Real, SVector, AxisInfo}) = get_spatial_info(pc.position, scale)
 
 function determine_offset(min_value, max_value, scale; threshold=10^7)
+    @show scale
+    @show min_value, max_value
+    @show threshold
     s = round(Int64, ((min_value + max_value) / 2) / scale / threshold)
     s *= threshold * scale
     # Try to convert back and forth and check overflow

--- a/src/vlrs.jl
+++ b/src/vlrs.jl
@@ -259,9 +259,14 @@ is_srs(vlr::LasVariableLengthRecord) = vlr.record_id in (
 """
     $(TYPEDSIGNATURES)
 
-Extract all VLRs with a `user_id` and `record_id` from a collection of VLRs, `vlrs`
+Extract the VLR with a `user_id` and `record_id` from a collection of VLRs, `vlrs`
 """
 function extract_vlr_type(vlrs::Vector{<:LasVariableLengthRecord}, user_id::String, record_id::Integer)
-    matches_ids = findall(vlr -> (get_user_id(vlr) == user_id) && (get_record_id(vlr) == record_id), vlrs)
-    return vlrs[matches_ids]
+    # there should only ever be 1 VLR that has a particular user/record ID combination
+    matches_ids = findfirst(vlr -> (get_user_id(vlr) == user_id) && (get_record_id(vlr) == record_id), vlrs)
+    if isnothing(matches_ids)
+        return nothing
+    else
+        return vlrs[matches_ids]
+    end
 end

--- a/src/write.jl
+++ b/src/write.jl
@@ -154,10 +154,10 @@ function get_record_bytes(records::StructVector{TRecord}, vlrs::Vector{LasVariab
 
     if user_field_bytes > 0
         # need to write the extra bytes fields in the same order as they appear in the VLR
-        extra_bytes_vlrs = extract_vlr_type(vlrs, LAS_SPEC_USER_ID, ID_EXTRABYTES)
-        @assert length(extra_bytes_vlrs) == 1 "Expected to find 1 Extra Bytes VLR, instead found $(length(extra_bytes_vlrs))"
+        extra_bytes_vlr = extract_vlr_type(vlrs, LAS_SPEC_USER_ID, ID_EXTRABYTES)
+        @assert !isnothing(extra_bytes_vlr) "Expected to find an Extra Bytes VLR but found none!"
         # get the order they appear in the VLR
-        user_field_names = unique(get_base_field_name.(Symbol.(name.(get_extra_bytes(get_data(extra_bytes_vlrs[1]))))))
+        user_field_names = unique(get_base_field_name.(Symbol.(name.(get_extra_bytes(get_data(extra_bytes_vlr))))))
         # create a mapping between the order in the VLR and the order in the record
         per_record_user_field_names = get_user_field_names(TRecord)
         user_field_idxs = indexin(user_field_names, collect(per_record_user_field_names))

--- a/src/write.jl
+++ b/src/write.jl
@@ -96,7 +96,10 @@ function write_las(io::IO, las::LASDataset)
     this_point_format = point_format(header)
     xyz = spatial_info(header)
 
-    user_fields = ismissing(las._user_data) ? () : filter(c -> c != :undocumented_bytes, columnnames(las._user_data))
+    cols = collect(columnnames(pc))
+    these_are_las_cols = cols .∈ Ref(RECOGNISED_LAS_COLUMNS)
+    other_cols = cols[.!these_are_las_cols]
+    user_fields = filter(c -> c != :undocumented_bytes, other_cols)
 
     write(io, header)
 

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -193,17 +193,20 @@
 
     # we should be able to add new points in too
     new_points = Table(
+        id = length(pc):(length(pc) + 10),
         position = rand(SVector{3, Float64}, 10),
         classification = rand(UInt8, 10),
         gps_time = rand(10),
-        id = length(pc):(length(pc) + 10),
         overlap = falses(10)
     )
     add_points!(las, new_points)
     pointcloud = get_pointcloud(las)
     # check the point contents to make sure our new points are there
     @test length(pointcloud) == 110
-    @test pointcloud[101:end] == new_points
+    # equality checks are annoying when the column order gets switched internally, so check each column individually
+    for col ∈ columnnames(new_points)
+        @test getproperty(pointcloud, col)[101:end] == getproperty(new_points, col)
+    end
     # also make sure our header information is correctly set
     @test number_of_points(las) == 110
     @test spatial_info(las) == LASDatasets.get_spatial_info(pointcloud)

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -58,9 +58,7 @@
     this_header = get_header(las)
     @test point_record_length(this_header) == LASDatasets.byte_size(LasPoint1) + 10
     # our user fields should be populated in the dataset
-    @test las._user_data isa FlexTable
-    @test length(las._user_data) == num_points
-    @test sort(collect(columnnames(las._user_data))) == [:other_thing, :thing]
+    @test sort(collect(columnnames(las.pointcloud))) == [:classification, :gps_time, :id, :other_thing, :position, :thing]
     this_pc = get_pointcloud(las)
     @test this_pc.thing == spicy_pc.thing
     @test this_pc.other_thing == spicy_pc.other_thing
@@ -183,4 +181,7 @@
     remove_vlr!(las, superseded_comment)
     @test number_of_evlrs(get_header(las)) == 1
     @test get_evlrs(las) == [new_commment]
+
+    # las = LASDataset(pc)
+    
 end

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -182,6 +182,12 @@
     @test number_of_evlrs(get_header(las)) == 1
     @test get_evlrs(las) == [new_commment]
 
-    # las = LASDataset(pc)
+    # test modifying point formats and versions
+    las = LASDataset(pc)
+
+    # if we add a LAS column that isn't covered by the current format, the point format (and possibly LAS version) should be updated in the header
+    add_column!(las, :overlap, falses(length(pc)))
+    @test point_format(get_header(las)) == LasPoint6
+    @test las_version(get_header(las)) == v"1.4"
     
 end

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -184,10 +184,26 @@
 
     # test modifying point formats and versions
     las = LASDataset(pc)
-
     # if we add a LAS column that isn't covered by the current format, the point format (and possibly LAS version) should be updated in the header
     add_column!(las, :overlap, falses(length(pc)))
     @test point_format(get_header(las)) == LasPoint6
     @test las_version(get_header(las)) == v"1.4"
+
+    # we should be able to add new points in too
+    new_points = Table(
+        position = rand(SVector{3, Float64}, 10),
+        classification = rand(UInt8, 10),
+        gps_time = rand(10),
+        id = length(pc):(length(pc) + 10),
+        overlap = falses(10)
+    )
+    add_points!(las, new_points)
+    pointcloud = get_pointcloud(las)
+    # check the point contents to make sure our new points are there
+    @test length(pointcloud) == 110
+    @test pointcloud[101:end] == new_points
+    # also make sure our header information is correctly set
+    @test number_of_points(las) == 110
+    @test spatial_info(las) == LASDatasets.get_spatial_info(pointcloud)
     
 end

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -117,9 +117,11 @@
         "Text Area Description", 
         TextAreaDescription("This is the new dataset description")
     )
-    add_vlr!(las, new_desc)
     # mark the old one as superseded
     set_superseded!(las, desc)
+    # and add the new one
+    add_vlr!(las, new_desc)
+    
     vlrs = get_vlrs(las)
     @test length(vlrs) == 3
     @test vlrs[3] == new_desc

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -190,10 +190,9 @@
     add_column!(las, :overlap, falses(length(pc)))
     @test point_format(get_header(las)) == LasPoint6
     @test las_version(get_header(las)) == v"1.4"
-
     # we should be able to add new points in too
     new_points = Table(
-        id = length(pc):(length(pc) + 10),
+        id = (length(pc) + 1):(length(pc) + 10),
         position = rand(SVector{3, Float64}, 10),
         classification = rand(UInt8, 10),
         gps_time = rand(10),
@@ -207,8 +206,17 @@
     for col ∈ columnnames(new_points)
         @test getproperty(pointcloud, col)[101:end] == getproperty(new_points, col)
     end
+    orig_pc = deepcopy(pointcloud)
     # also make sure our header information is correctly set
     @test number_of_points(las) == 110
     @test spatial_info(las) == LASDatasets.get_spatial_info(pointcloud)
+
+    # we can also delete these points if we want
+    remove_points!(las, 101:110)
+    @test number_of_points(las) == 100
+    pc = get_pointcloud(las)
+    for col ∈ columnnames(pc)
+        @test getproperty(pc, col) == getproperty(orig_pc, col)[1:100]
+    end
     
 end

--- a/test/header.jl
+++ b/test/header.jl
@@ -44,20 +44,14 @@
     # the point return counts should match the legacy counts here
     @test get_number_of_points_by_return(header) == (100, 0, 0, 0, 0)
 
-    # we shouldn't be able to set an invalid point format
-    @test_throws ErrorException set_point_format!(header, LasPoint10)
-
-    # and we should be able to set the version back again
-    set_las_version!(header, v"1.4")
+    # if we request setting to a higher point format than the LAS version in the header supports, the version should be updated to the minimal compatible one
+    set_point_format!(header, LasPoint7)
     @test las_version(header) == v"1.4"
     @test header_size(header) == 375
     @test point_data_offset(header) == 376
-
     
-    # but if we change to a newer LAS point format, we should get the same return counts, but set the legacy counts internally to 0
-    set_point_format!(header, LasPoint7)
+    # now, we should get the same return counts, but set the legacy counts internally to 0
     @test get_number_of_points_by_return(header) == (100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-    # and the legacy counts should be 0
     @test header.legacy_point_return_count == (0, 0, 0, 0, 0)
 
     set_point_format!(header, LasPoint1)


### PR DESCRIPTION
# Ability to flexibly modify point data and header info in LAS Dataset

## Description
Adding the functionality to let users modify the point data or header information relating to the point data in a `LASDataset` without invalidating the header of the LAS file. 
The main use case here is if you have some `LASDataset` and you want to add extra LAS fields to it (that aren't already present, and maybe don't correspond to the point version currently stored in your header). For example, if you have a file with the LasPoint0 format, but want to add an overlap column, you can do
```julia
las = load_las(...)
add_column!(las, :overlap, falses(number_of_points(las)))`
```
This will update the header information appropriately as well as the actual point data.
Additionally, you can opt to change the point format or las version specifically (without changing the point data itself).
The benefit of these changes is that if you load in a LAS file, do some processing, and then need to output it in a different format, you can do it without having to create a whole new `LASDataset`.

On top of this, you can add extra points to your dataset too using the new `add_points!` function (where one caveat is if your new points are missing any fields that are in the LAS dataset, they'll be filled in with zeroes)

To make this work, I've redone the internals of how we store point data, changing to use a single `FlexTable` instead of a core `TypedTable` and an optional `FlexTable` just containing user data. This may be slightly less performant in some operations over the point data due to type inference overhead, however I think the flexibility in the UI justifies this

## Types of Changes

- New feature (non-breaking change which adds functionality)
- Bug fix (non-breaking change which fixes an issue)
- Refactor/improvements
- Documentation / non-code

## Tasks
  - [x] Functions to modify header format properties
  - [x] Plumb header functions through `LASDataset` objects
  - [x] Modify `add_column!` to work for LAS fields as well as user fields
  - [x] Ability to add points to `LASDataset`
  - [x] Documentation of API changes

## Review
- [x] Tests
