### PR TITLE
VLR String Description Inconsistency

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -20,7 +20,7 @@ end
 Write a string `str` to an IO channel `io`, writing exactly `nb` bytes (padding if `str` is too short)
 """
 function writestring(io, str::AbstractString, nb::Integer)
-    n = length(str)
+    n = Base.sizeof(str)
     npad = nb - n
     @assert npad ≥ 0 "String length $(n) exceeds number of bytes $(nb)"
     if npad == 0

--- a/test/util.jl
+++ b/test/util.jl
@@ -27,4 +27,20 @@
     LASDatasets.writestring(io, "", 5)
     seek(io, 0)
     @test LASDatasets.readstring(io, 5) == ""
+
+    # test with special characters whose ASCII encoding is > 0x80, meaning their number of "code units" will be 2, not one
+    # see here for more details: https://docs.julialang.org/en/v1/manual/strings/#Unicode-and-UTF-8
+    str = "aβcd"
+    take!(io)
+    LASDatasets.writestring(io, str, 5)
+    seek(io, 0)
+    bytes = read(io)
+    @test String(bytes)== str
+
+    # and we should still get the correct buffer if we ask for more bytes
+    take!(io)
+    LASDatasets.writestring(io, str, 7)
+    seek(io, 0)
+    bytes = read(io)
+    @test String(bytes) == "$(str)\0\0"
 end


### PR DESCRIPTION
# Fix inconsistency in writestring due to unicode encoding

## Description
This fixes a bug that crops up sometimes when reading VLRs and EVLRs from a LAS file whose descriptions contain unicode characters with 2 bytes of length instead of 1. Basically, when we write a VLR description, we call `writestring(io, description, 32)` (since as per the LAS spec, the description should be 32 bytes in length). However, `writestring` would add a buffer to the string (trailing "\0" 's) if **`length(description)`** is < 32, even if `size(description) == 32`, meaning we're adding extra bytes to the file causing some corruptions down the line. 
This turns into a simple fix, just replacing `length` with `size` in `writestring`

## Types of Changes

- Bug fix (non-breaking change which fixes an issue)

## Review
_List of tasks the reviewer must do to review the PR_
- [x] Tests
- [x] Documentation
- [x] CHANGELOG
