### PR TITLE
Handle no wkt but supplied units

### DIFF
--- a/src/georef.jl
+++ b/src/georef.jl
@@ -242,7 +242,9 @@ end
 
 get_wkt_string(ogc_wkt::OGC_WKT) = ogc_wkt.wkt_str
 get_horizontal_unit(ogc_wkt::OGC_WKT) = ogc_wkt.unit
+get_horizontal_unit(::Missing) = missing
 get_vertical_unit(ogc_wkt::OGC_WKT) = ogc_wkt.vert_unit
+get_vertical_unit(::Missing) = missing
 
 """
     $(TYPEDSIGNATURES)
@@ -250,7 +252,7 @@ get_vertical_unit(ogc_wkt::OGC_WKT) = ogc_wkt.vert_unit
 Given an OGC WKT coordinate system `wkt`, attempt to parse conversion units (to metres) with optional operator supplied overrides.
 Can opt to convert all axes units or just the vertical.
 """
-function conversion_from_vlrs(wkt::OGC_WKT; 
+function conversion_from_vlrs(wkt::Union{OGC_WKT, Missing}; 
                                 convert_x_y_units::Union{String, Missing} = missing, 
                                 convert_z_units::Union{String, Missing} = missing)::Union{Missing, SVector{3}}
     

--- a/src/read.jl
+++ b/src/read.jl
@@ -94,7 +94,8 @@ Read LAS data from an IO source
 function read_las_data(io::TIO, required_columns::TTuple=DEFAULT_LAS_COLUMNS;
                         convert_to_metres::Bool = true,
                         convert_x_y_units::Union{String, Missing} = missing,
-                        convert_z_units::Union{String, Missing} = missing) where {TIO <: Union{Base.AbstractPipe,IO}, TTuple}
+                        convert_z_units::Union{String, Missing} = missing,
+                        verbose::Bool = false) where {TIO <: Union{Base.AbstractPipe,IO}, TTuple}
 
     header = read(io, LasHeader)
 
@@ -118,7 +119,7 @@ function read_las_data(io::TIO, required_columns::TTuple=DEFAULT_LAS_COLUMNS;
     as_table = make_table(records, required_columns, xyz)
 
     conversion = if convert_to_metres
-        convert_units!(as_table, vlrs, convert_x_y_units, convert_z_units)
+        convert_units!(as_table, vlrs, convert_x_y_units, convert_z_units, verbose = verbose)
     else
         NO_CONVERSION
     end

--- a/src/read.jl
+++ b/src/read.jl
@@ -264,8 +264,9 @@ function convert_units!(pointcloud::AbstractVector{<:NamedTuple}, vlrs::Vector{L
         if ismissing(convert_x_y_units) && ismissing(convert_z_units) && count(these_are_wkts) == 0
             return NO_CONVERSION
         else
-            ogc_wkt = if count(these_are_wkts) != 1
-                @info "Expected to find 1 OGC WKT VLR, instead found $(count(these_are_wkts))"
+            @assert count(these_are_wkts) <= 1 "Expected to find 1 OGC WKT VLR, instead found $(count(these_are_wkts))"
+            ogc_wkt = if count(these_are_wkts) == 0
+                verbose && @info "No OGC WKT VLR found"
                 missing
             else
                 get_data(vlrs[findfirst(these_are_wkts)])

--- a/src/read.jl
+++ b/src/read.jl
@@ -263,8 +263,12 @@ function convert_units!(pointcloud::AbstractVector{<:NamedTuple}, vlrs::Vector{L
         if ismissing(convert_x_y_units) && ismissing(convert_z_units) && count(these_are_wkts) == 0
             return NO_CONVERSION
         else
-            @assert count(these_are_wkts) == 1 "Expected to find 1 OGC WKT VLR, instead found $(count(these_are_wkts))"
-            ogc_wkt = get_data(vlrs[findfirst(these_are_wkts)])
+            ogc_wkt = if count(these_are_wkts) != 1
+                @info "Expected to find 1 OGC WKT VLR, instead found $(count(these_are_wkts))"
+                missing
+            else
+                get_data(vlrs[findfirst(these_are_wkts)])
+            end
             conversion = conversion_from_vlrs(ogc_wkt, convert_x_y_units = convert_x_y_units, convert_z_units = convert_z_units)
             if !ismissing(conversion) && any(conversion .!= 1.0)
                 verbose && @info "Positions converted to meters using conversion $(conversion)"


### PR DESCRIPTION
# Handle no wkt but supplied units

## Description
allow units to be supplied and used even if there is no ogc_wkt and fixed the plumbing through of the verbose kwarg

## Types of Changes
- Bug fix (non-breaking change which fixes an issue)

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG
